### PR TITLE
feat(KAF): change the error rules

### DIFF
--- a/src/_internal/molecules/ArrayCards.tsx
+++ b/src/_internal/molecules/ArrayCards.tsx
@@ -53,6 +53,7 @@ const ArrayCards = (props: Props) => {
     onChange,
   } = props;
   const itemSpec = Array.isArray(spec.items) ? spec.items[0] : spec.items;
+  const errorInfo = props.field?.error || props.error;
 
   return (
     <>
@@ -65,11 +66,7 @@ const ArrayCards = (props: Props) => {
             spec={itemSpec as JSONSchema7}
             subKey={`${props.field?.key}-${itemIndex}`}
             index={itemIndex}
-            error={
-              props.field?.error instanceof Array
-                ? props.field.error[itemIndex]
-                : ""
-            }
+            error={errorInfo instanceof Array ? errorInfo[itemIndex] : ""}
             widgetOptions={{
               ...widgetOptions,
               title: widgetOptions?.title

--- a/src/_internal/molecules/ArrayGroups.tsx
+++ b/src/_internal/molecules/ArrayGroups.tsx
@@ -55,6 +55,7 @@ const ArrayGroups = (props: Props) => {
     onChange,
   } = props;
   const itemSpec = Array.isArray(spec.items) ? spec.items[0] : spec.items;
+  const errorInfo = props.field?.error || props.error;
 
   return (
     <>
@@ -67,11 +68,7 @@ const ArrayGroups = (props: Props) => {
             spec={itemSpec as JSONSchema7}
             subKey={`${props.field?.key}-${itemIndex}`}
             index={itemIndex}
-            error={
-              props.field?.error instanceof Array
-                ? props.field.error[itemIndex]
-                : ""
-            }
+            error={errorInfo instanceof Array ? errorInfo[itemIndex] : ""}
             widgetOptions={{
               ...widgetOptions,
               title: widgetOptions?.title
@@ -107,7 +104,10 @@ const ArrayGroups = (props: Props) => {
             size="medium"
             onClick={() => {
               onChange(
-                value.concat(props.field?.defaultValue?.[0] ?? generateFromSchema(itemSpec as JSONSchema7))
+                value.concat(
+                  props.field?.defaultValue?.[0] ??
+                    generateFromSchema(itemSpec as JSONSchema7)
+                )
               );
             }}
           >

--- a/src/_internal/molecules/ArrayItems.tsx
+++ b/src/_internal/molecules/ArrayItems.tsx
@@ -61,6 +61,7 @@ const ArrayItems = (props: Props) => {
     Array.isArray(spec.items) ? spec.items[0] : spec.items
   ) as JSONSchema7;
   const kit = useContext(KitContext);
+  const errorInfo = props.field?.error || props.error;
 
   return (
     <>
@@ -70,11 +71,7 @@ const ArrayItems = (props: Props) => {
             <SpecField
               {...props}
               field={undefined}
-              error={
-                props.field?.error instanceof Array
-                  ? props.field.error[itemIndex]
-                  : ""
-              }
+              error={errorInfo instanceof Array ? errorInfo[itemIndex] : ""}
               widget="default"
               value={itemValue}
               subKey={`${props.field?.key}-${itemIndex}`}

--- a/src/_internal/molecules/AutoForm/ObjectField.tsx
+++ b/src/_internal/molecules/AutoForm/ObjectField.tsx
@@ -6,9 +6,10 @@ import { getJsonSchemaByPath } from "src/_internal/utils/schema";
 import { immutableSet } from "../../../editor/utils/object";
 import { get } from "lodash";
 import type { Field } from "../../organisms/KubectlApplyForm/type";
+import { isObject } from "lodash";
 
 export function resolveSubFields(props: WidgetProps) {
-  const { field, spec, value, path, level, onChange } = props;
+  const { field, spec, value, path, level, error, onChange } = props;
   const fields: Field[] = field?.fields || [];
   const properties = Object.keys(spec.properties || {});
 
@@ -18,10 +19,18 @@ export function resolveSubFields(props: WidgetProps) {
       if (!subField.path) return null;
 
       const subSpec = getJsonSchemaByPath(spec, subField.path) || {};
+      const errorInfo = subField?.error || error;
 
       return (
         <SpecField
           {...props}
+          error={
+            errorInfo &&
+            isObject(errorInfo) &&
+            subField?.key
+              ? (errorInfo[subField.key as keyof typeof errorInfo]) as string
+              : errorInfo
+          }
           field={subField}
           widget={subField.widget}
           widgetOptions={subField.widgetOptions}
@@ -64,10 +73,13 @@ export function resolveSubFields(props: WidgetProps) {
           value={value?.[name]}
           widgetOptions={{}}
           onChange={(newValue, key) => {
-            onChange({
-              ...(value || {}),
-              [name]: newValue,
-            }, key);
+            onChange(
+              {
+                ...(value || {}),
+                [name]: newValue,
+              },
+              key
+            );
           }}
         />
       );

--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -51,12 +51,14 @@ const FormItemStyle = css`
     margin-bottom: 0;
   }
 
-  &.dovetail-ant-form-item:not(.dovetail-ant-form-item-has-error) .dovetail-ant-form-item-explain {
+  &.dovetail-ant-form-item
+    > .dovetail-ant-form-item-control
+    > .dovetail-ant-form-item-explain {
     display: none;
   }
 
   &.dovetail-ant-form-item-has-error {
-    & .dovetail-ant-form-item-explain {
+    & > .dovetail-ant-form-item-control > .dovetail-ant-form-item-explain {
       display: block;
     }
   }
@@ -212,6 +214,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
   const FieldComponent = (
     <Component
       widgetOptions={widgetOptions}
+      error={typeof error !== 'string' ? error : undefined}
       field={field}
       spec={spec}
       value={value}
@@ -244,13 +247,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
         displayLabel={displayLabel}
         displayDescription={displayDescription}
         spec={spec}
-        error={
-          field?.error instanceof Array
-            ? index !== undefined
-              ? field.error[index]
-              : ""
-            : field?.error || error
-        }
+        error={typeof error === "string" ? error : ""}
       >
         {slot?.({ ...field, index }, FieldComponent, `filed_${path}`) ||
           FieldComponent}

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -21,7 +21,7 @@ export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
   stepElsRef: Record<number, HTMLElement | null>;
   subKey?: string;
   index?: number;
-  error?: string;
+  error?: string | string[] | Record<string, string>;
   value: Value;
   onChange: (newValue: Value, key?: string) => void;
   slot?: Function;

--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
@@ -114,6 +114,7 @@ const KubectlApplyForm = React.forwardRef<
         <SpecField
           key={f.dataPath || f.key}
           field={f}
+          error={f.error}
           widget={f.widget}
           widgetOptions={f.widgetOptions}
           spec={{ ...spec, title: f.label }}

--- a/src/_internal/organisms/KubectlApplyForm/type.ts
+++ b/src/_internal/organisms/KubectlApplyForm/type.ts
@@ -7,7 +7,7 @@ export type Field = {
   isDisplayLabel: boolean;
   helperText: string;
   sectionTitle: string;
-  error: string | string[];
+  error: string | string[] | Record<string, string>;
   condition?: boolean;
   widget?: string;
   widgetOptions?: Record<string, any>;


### PR DESCRIPTION
### 修改给字段编写校验错误信息的规则

#### 之前
之前想给数组字段里的每项可以给字段编写一个数组类型的 `error` ，然后 KAF 会对 `error` 进行遍历，分发到每一项。

比如想给数组字段里的子字段`name` 添加错误信息，要这样配置：
```js
{
  path: 'workers.$add',
  key: 'workers',
  fields: [
    {
      path: 'name',
      key: 'name',
      error: '{{values.map((_, index)=> validatedResult[`workers-${index}-name`])}}'
    }
  ]
}
```

但是这种方法有个问题，没法给**数组字段**里的**数组子字段**整体添加校验规则，因为给**数组子字段**的`error`传数组的话，它会分发给它的子项，而不是它本身。比如有个数组子字段`dns`：
```js
{
  path: 'pools.$add',
  key: 'pools',
  fields: [
    {
      path: 'dns.$add',
      key: 'dns',
      error: '{{values.map((_, index)=> validatedResult[`pools-${index}-dns`])}}'  // 分发给它的子项，而不是它整个字段本身
    }
  ]
}
```

因此，需要修改下`error`的规则。

#### 现在
现在想给子项编写校验错误信息可以在数字字段本身为子项编写`error`，而不是在子字段：
```js
{
  path: 'pools.$add',
  key: 'pools',
  error: '{{values.map((_, index)=> ({ dns: validatedResult[`pools-${index}-dns`]}) ) }}',  // 分发给每项的子字段`dns`，根据`key`匹配
  fields: [
    {
      path: 'dns.$add',
      key: 'dns',
      // error: '{{dns.map((_, dnsIndex)=> (validatedResult[`dns-${dnsIndex}-dns`]) ) }}'  // 如果想给每项配置校验错误信息，可以这样写
    }
  ]
}
```

![image](https://user-images.githubusercontent.com/25414733/192739627-5c027cf2-1abd-41f5-8ce1-efb58cf150c6.png)
