### PR TITLE
feat(KAF): add k8sSelect widget and use it for namespace

### DIFF
--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -13,8 +13,12 @@ import NumberField from "./NumberField";
 import NullField from "./NullField";
 import ObjectField from "./ObjectField";
 import MultiSpecField from "./MultiSpecField";
-import { FORM_WIDGETS_MAP } from "../../molecules/form";
+import {
+  FORM_WIDGETS_MAP,
+  FORM_WIDGET_OPTIONS_MAP,
+} from "../../molecules/form";
 import { Typo } from "../../atoms/themes/CloudTower/styles/typo.style";
+import { Static } from "@sinclair/typebox";
 
 type TemplateProps = {
   id?: string;
@@ -123,7 +127,10 @@ const DefaultTemplate: React.FC<TemplateProps> = (props) => {
       labelAlign="left"
       label={
         displayLabel ? (
-          <span style={{ width: labelWidth || 108 + 'px' }} className={cx(Typo.Label.l3_regular_title, FormItemLabelStyle)}>
+          <span
+            style={{ width: labelWidth || 108 + "px" }}
+            className={cx(Typo.Label.l3_regular_title, FormItemLabelStyle)}
+          >
             {label}
           </span>
         ) : (
@@ -162,10 +169,10 @@ type SpecFieldProps = WidgetProps & {
 
 const SpecField: React.FC<SpecFieldProps> = (props) => {
   const {
+    basePath,
     field,
     spec,
     widget,
-    widgetOptions = {},
     level,
     path,
     step,
@@ -178,6 +185,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
     slot,
     onChange,
   } = props;
+  let { widgetOptions = {} } = props;
   const { title } = spec;
   const label = title ?? "";
   const displayLabel = field?.isDisplayLabel ?? shouldDisplayLabel(spec, label);
@@ -193,6 +201,15 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
   // type fields
   if (widget && widget in FORM_WIDGETS_MAP) {
     Component = FORM_WIDGETS_MAP[widget as keyof typeof FORM_WIDGETS_MAP];
+  } else if (field?.path.includes("metadata.namespace")) {
+    Component = FORM_WIDGETS_MAP.k8sSelect;
+    widgetOptions = {
+      apiBase: "/api/v1",
+      basePath,
+      resource: "namespaces",
+      valuePath: 'metadata.name',
+      ...widgetOptions,
+    } as Static<typeof FORM_WIDGET_OPTIONS_MAP.k8sSelect>;
   } else if (spec.type === "object") {
     Component = ObjectField;
     isNest = true;
@@ -216,7 +233,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
   const FieldComponent = (
     <Component
       widgetOptions={widgetOptions}
-      error={typeof error !== 'string' ? error : undefined}
+      error={typeof error !== "string" ? error : undefined}
       field={field}
       spec={spec}
       value={value}

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -8,6 +8,7 @@ type WidgetOptions = Partial<{
 }>;
 
 export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
+  basePath: string;
   field?: Field;
   spec: JSONSchema7;
   widget?: string;

--- a/src/_internal/molecules/K8sSelect.tsx
+++ b/src/_internal/molecules/K8sSelect.tsx
@@ -1,0 +1,117 @@
+import { Select as AntdSelect } from "antd";
+import { Type, Static } from "@sinclair/typebox";
+import { WidgetProps } from "./AutoForm/widget";
+import { KitContext } from "../atoms/kit-context";
+import { useContext, useEffect, useState, useMemo } from "react";
+import {
+  KubeApi,
+  UnstructuredList,
+} from "../../_internal/k8s-api-client/kube-api";
+import { compact, get } from "lodash";
+
+export const OptionsSpec = Type.Object({
+  basePath: Type.String({
+    title: "Base path",
+    description: "K8s Api base path",
+  }),
+  watchWsBasePath: Type.String({
+    title: "Watch websocket base path",
+  }),
+  apiBase: Type.String({
+    title: "Api base",
+    description: "K8s resource api base, e.g, /apis/apps/v1",
+  }),
+  namespace: Type.String({
+    title: "Namespace",
+    description: "namespace filter",
+  }),
+  resource: Type.String({
+    title: "Resource",
+  }),
+  fieldSelector: Type.String({
+    title: "Field selector",
+  }),
+  valuePath: Type.String({
+    title: "Value path",
+  }),
+  disabled: Type.Optional(Type.Boolean()),
+});
+
+type Props = WidgetProps<string | string[], Static<typeof OptionsSpec>>;
+
+const K8sSelect = (props: Props) => {
+  const kit = useContext(KitContext);
+  const { value, onChange, widgetOptions } = props;
+  const {
+    basePath,
+    watchWsBasePath,
+    apiBase,
+    resource,
+    namespace,
+    fieldSelector,
+    valuePath,
+    disabled,
+  } = widgetOptions || { options: [] };
+  const [options, setOptions] = useState<{ label?: string; value?: string }[]>(
+    []
+  );
+
+  const api = useMemo(
+    () =>
+      new KubeApi<UnstructuredList>({
+        basePath: basePath || "",
+        watchWsBasePath,
+        objectConstructor: {
+          kind: "",
+          apiBase: `${apiBase}/${resource}`,
+          namespace: namespace || '',
+        },
+      }),
+    [basePath, watchWsBasePath, apiBase, resource, namespace]
+  );
+
+  useEffect(() => {
+    (async function () {
+      const result = await api.list({
+        query: {
+          namespace: namespace || '',
+          fieldSelector: compact([fieldSelector]).join(","),
+        },
+      });
+
+      setOptions(
+        (result?.items || []).map((item) => ({
+          label: get(item, valuePath || ""),
+          value: get(item, valuePath || ""),
+        }))
+      );
+    })();
+  }, [api, fieldSelector]);
+
+  return (
+    <kit.Select
+      disabled={disabled}
+      value={(value || "") as any}
+      onChange={(value) =>
+        onChange(
+          value,
+          `${
+            props.subKey ? `${props.subKey}${props.field?.key ? "-" : ""}` : ""
+          }${props.field?.key || ""}`
+        )
+      }
+      showSearch
+      optionFilterProp="children"
+    >
+      {options.map((option, idx) => {
+        return (
+          <AntdSelect.Option key={idx} value={option.value || ""}>
+            {option.label}
+          </AntdSelect.Option>
+        );
+      })}
+    </kit.Select>
+  );
+};
+
+export default K8sSelect;

--- a/src/_internal/molecules/form.ts
+++ b/src/_internal/molecules/form.ts
@@ -7,6 +7,7 @@ import InputNumber, {
 import Switch, { OptionsSpec as SwitchOptionsSpec } from "./Switch";
 import Card, { OptionsSpec as CardOptionsSpec } from "./Card";
 import ArrayCards, { OptionsSpec as ArrayCardsOptionsSpec } from "./ArrayCards";
+import K8sSelect, { OptionsSpec as K8sSelectOptionsSpec } from "./K8sSelect";
 
 export const FORM_WIDGETS_MAP = {
   input: Input,
@@ -16,6 +17,7 @@ export const FORM_WIDGETS_MAP = {
   switch: Switch,
   card: Card,
   arrayCards: ArrayCards,
+  k8sSelect: K8sSelect,
 };
 export const FORM_WIDGET_OPTIONS_MAP = {
   input: InputOptionsSpec,
@@ -25,4 +27,5 @@ export const FORM_WIDGET_OPTIONS_MAP = {
   switch: SwitchOptionsSpec,
   card: CardOptionsSpec,
   arrayCards: ArrayCardsOptionsSpec,
+  k8sSelect: K8sSelectOptionsSpec,
 };

--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
@@ -78,6 +78,7 @@ const KubectlApplyForm = React.forwardRef<
 >(
   (
     {
+      basePath,
       className,
       schemas = [],
       uiConfig,
@@ -113,6 +114,7 @@ const KubectlApplyForm = React.forwardRef<
       const component = (
         <SpecField
           key={f.dataPath || f.key}
+          basePath={basePath}
           field={f}
           error={f.error}
           widget={f.widget}


### PR DESCRIPTION
KAF 添加 K8sSelect Widget 用于选择 k8s 资源相关的信息，并默认用于 namespace 字段。

<img width="891" alt="image" src="https://user-images.githubusercontent.com/25414733/196351866-620162c8-d775-4a37-a6c5-e5a5b313839c.png">
