### PR TITLE
feat(KAF): pass the path to the slot props

### DIFF
--- a/src/_internal/molecules/AutoForm/ArrayField.tsx
+++ b/src/_internal/molecules/AutoForm/ArrayField.tsx
@@ -5,6 +5,7 @@ import { KitContext } from "../../atoms/kit-context";
 import { generateFromSchema } from "../../utils/schema";
 import ArrayGroups from "../ArrayGroups";
 import ArrayItems from "../ArrayItems";
+import { useTranslation } from "react-i18next";
 
 const ArrayField: React.FC<WidgetProps> = (props) => {
   const { spec, value = [], path, level, widgetOptions, onChange } = props;
@@ -31,6 +32,7 @@ const ArrayField: React.FC<WidgetProps> = (props) => {
 };
 
 export const AddToArrayField: React.FC<WidgetProps> = (props) => {
+  const { t } = useTranslation();
   const kit = useContext(KitContext);
   const { field, spec, value = [], onChange } = props;
   const itemSpec = Array.isArray(spec.items) ? spec.items[0] : spec.items;
@@ -53,7 +55,7 @@ export const AddToArrayField: React.FC<WidgetProps> = (props) => {
           );
         }}
       >
-        添加
+        {t("dovetail.add")}
       </kit.Button>
     </div>
   );

--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -269,7 +269,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
         spec={spec}
         error={typeof error === "string" ? error : ""}
       >
-        {slot?.({ ...field, index }, FieldComponent, `filed_${path}`) ||
+        {slot?.({ path, ...(field || {}), index }, FieldComponent, `filed_${path}`) ||
           FieldComponent}
       </DefaultTemplate>
     </Col>


### PR DESCRIPTION
KAF 不管有没有 `field` 都传递当前字段属性的 path 给 slot props，让数组类型的子项也能根据 path 配置自定义组件