### PR TITLE
feat: add renderedValue for render widget

### DIFF
--- a/src/sunmao/components/KubectlGetTable.tsx
+++ b/src/sunmao/components/KubectlGetTable.tsx
@@ -516,7 +516,8 @@ export const KubectlGetTable = implementRuntimeComponent({
               return renderWidget(
                 { ...col, path: col.dataIndex },
                 {
-                  value: value ?? "-",
+                  value: value, 
+                  renderedValue: value ?? "-", 
                   record,
                   index,
                 },

--- a/src/sunmao/utils/widget.tsx
+++ b/src/sunmao/utils/widget.tsx
@@ -15,13 +15,13 @@ export type Field = {
 
 export function renderWidget(
   field: Field,
-  data: { value: any; [props: string]: any },
+  data: { value: any; renderedValue?: any; [props: string]: any },
   slot?: Function,
   slotKey?: string
 ) {
-  const { value, record } = data;
+  const { value, record, renderedValue } = data;
   const { widget, widgetOptions = {}, transform, ...restField } = field;
-  const transformedValue = transform ? transform(restField, data) : value;
+  const transformedValue = transform ? transform(restField, data) : (renderedValue ?? value);
   let node = transformedValue;
 
   if (widget && widget !== "default") {
@@ -32,19 +32,19 @@ export function renderWidget(
     node = WidgetComponent ? (
       <WidgetComponent {...widgetOptions} value={transformedValue} />
     ) : (
-      value
+      transformedValue
     );
   } else {
     // apply the widget by path
     if (field.path === "metadata.creationTimestamp") {
-      node = <ObjectAge value={value} />;
+      node = <ObjectAge value={transformedValue} />;
     } else if (
       field.path === "metadata.labels" ||
       field.path === "metadata.annotations"
     ) {
       node = (
         <ObjectLabel
-          value={Object.entries(value || {}).map(
+          value={Object.entries(transformedValue || {}).map(
             ([key, value]) => `${key}: ${value}`
           )}
         />


### PR DESCRIPTION
- `renderWidget` 新增 `renderedValue` 参数用于没有 slot 时的值展示，不再修改要传递给 slot 的 value，因为在使用者不知道 value 被修改的情况下会导致意外的逻辑错误