### PR TITLE
feat: add the registry

### DIFF
--- a/src/_internal/molecules/ArrayGroups.tsx
+++ b/src/_internal/molecules/ArrayGroups.tsx
@@ -11,6 +11,8 @@ import { generateFromSchema } from "../utils/schema";
 import { JSONSchema7 } from "json-schema";
 import { useTranslation } from "react-i18next";
 import { cloneDeep } from "lodash";
+import registry from "../../services/Registry";
+import { StringUnion } from "@sunmao-ui/runtime";
 
 const AddedButtonStyle = css``;
 
@@ -34,6 +36,14 @@ export const OptionsSpec = Type.Object({
       title: "Min Length",
     })
   ),
+  collapsible: Type.Optional(
+    Type.Boolean({
+      title: "Collapsible",
+    })
+  ),
+  icon: Type.Optional(
+    StringUnion([...registry.icons.keys()], { title: "Icon" })
+  ),
 });
 
 type Props = WidgetProps<any[], Static<typeof OptionsSpec>>;
@@ -52,6 +62,10 @@ const ArrayGroups = (props: Props) => {
       addable: true,
       addedButtonText: t("dovetail.add"),
       addedButtonIcon: "",
+      maxLength: undefined,
+      minLength: undefined,
+      icon: "",
+      collapsible: false,
     },
     onChange,
   } = props;
@@ -75,6 +89,8 @@ const ArrayGroups = (props: Props) => {
               title: widgetOptions?.title
                 ? `${widgetOptions?.title} ${itemIndex + 1}`
                 : "",
+              collapsible: widgetOptions.collapsible,
+              icon: widgetOptions.icon,
             }}
             path={path.concat(`.${itemIndex}`)}
             level={level + 1}

--- a/src/_internal/molecules/Group.tsx
+++ b/src/_internal/molecules/Group.tsx
@@ -9,6 +9,8 @@ import { Row, Collapse } from "antd";
 import { Typo } from "../atoms/themes/CloudTower/styles/typo.style";
 import { css } from "@emotion/css";
 import Icon from "../atoms/themes/CloudTower/components/Icon/Icon";
+import registry from "../../services/Registry";
+import { StringUnion } from "@sunmao-ui/runtime";
 
 const { Panel } = Collapse;
 
@@ -47,6 +49,7 @@ const GroupWrapperStyle = css`
   .arrow-icon {
     transition: transform 0.28s ease;
     transform: rotate(-180deg);
+    margin-right: 8px;
   }
 
   & .dovetail-ant-collapse-item-active {
@@ -69,11 +72,20 @@ const GroupHeader = styled.div`
   display: flex;
   justify-content: space-between;
 `;
-const GroupTitle = styled.h5`
+const GroupTitleWrapper = styled.h5`
   color: rgba(44, 56, 82, 0.6);
   display: flex;
   align-items: center;
   margin-bottom: 0;
+`;
+const GroupIcon = styled.span`
+  display: flex;
+  align-items: center;
+  margin-right: 6px;
+  vertical-align: top;
+`;
+const GroupTitle = styled.span`
+  vertical-align: top;
 `;
 const GroupBodyStyle = css`
   padding-bottom: 0;
@@ -91,6 +103,9 @@ export const OptionsSpec = Type.Object({
       title: "Collapsible",
     })
   ),
+  icon: Type.Optional(
+    StringUnion([...registry.icons.keys()], { title: "Icon" })
+  ),
 });
 
 type GroupProps = WidgetProps<
@@ -103,6 +118,7 @@ type GroupProps = WidgetProps<
 const Group = (props: GroupProps) => {
   const { widgetOptions, onRemove } = props;
   const kit = useContext(KitContext);
+  const icon = registry.icons.get(widgetOptions?.icon as any);
 
   return (
     <Collapse className={GroupWrapperStyle} defaultActiveKey={["panel"]}>
@@ -110,15 +126,16 @@ const Group = (props: GroupProps) => {
         key="panel"
         header={
           <GroupHeader>
-            <GroupTitle className={Typo.Label.l2_regular}>
+            <GroupTitleWrapper className={Typo.Label.l2_regular}>
               {widgetOptions?.collapsible ? (
                 <Icon
                   className="arrow-icon"
                   type="1-caret-triangle-down-16"
                 ></Icon>
               ) : null}
-              {widgetOptions?.title}
-            </GroupTitle>
+              {icon ? <GroupIcon>{icon}</GroupIcon> : null}
+              <GroupTitle>{widgetOptions?.title}</GroupTitle>
+            </GroupTitleWrapper>
             {onRemove ? (
               <span>
                 <kit.Button size="small" type="text" onClick={onRemove}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { libs as K8sLib } from "./sunmao/lib";
 import './locales';
+import registry from "./services/Registry";
 
 export { KubeApi } from './_internal/k8s-api-client/kube-api'
 export { K8sLib };
 export { widgets as editorWidgets } from "./editor/widgets";
+export { registry };

--- a/src/services/Registry.tsx
+++ b/src/services/Registry.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+class Registry {
+  public icons: Map<string, React.ReactNode> = new Map();
+
+  registerIcon(name: string, icon: React.ReactNode): void {
+    if (this.icons.has(name)) {
+    } else {
+      this.icons.set(name, icon);
+    }
+  }
+}
+
+const registry = new Registry();
+
+export default registry;


### PR DESCRIPTION
增加 Registry 来注册一些外部注入供组件配置中使用。目前只支持注册 Icon，然后在 KAF widget 的 `widgetOptions` 使用，因为不是所有 widget 都有 Icon 的，所以不好处理成 slot ，而是在特定的 widget 的 `widgetOptions` 允许配置 Icon 会比较好。

### 使用示例
#### 注册图标
```js
import { registry } from 'kui-shadow';

registry.registerIcon('icon-name', <Icon type="icon" />);
```
#### 在 KAF `widgetOptions` 中使用
```js
{
  icon: 'icon-name'
}
```