### PR TITLE
feat(KAF): add `displayValues` for the summary list

### DIFF
--- a/src/_internal/molecules/ArrayCards.tsx
+++ b/src/_internal/molecules/ArrayCards.tsx
@@ -2,7 +2,7 @@ import { WidgetProps } from "./AutoForm/widget";
 import Card from "./Card";
 import { Type, Static } from "@sinclair/typebox";
 import { KitContext } from "../atoms/kit-context";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { css } from "@emotion/css";
 import Icon, {
   IconTypes,
@@ -41,6 +41,7 @@ const ArrayCards = (props: Props) => {
   const kit = useContext(KitContext);
   const {
     value,
+    displayValues,
     spec,
     path,
     level,
@@ -79,15 +80,23 @@ const ArrayCards = (props: Props) => {
             onRemove={
               value.length > (widgetOptions?.minLength || 0)
                 ? () => {
-                    onChange(value.filter((v, i) => i !== itemIndex));
+                    onChange(
+                      value.filter((v, i) => i !== itemIndex),
+                      displayValues
+                    );
                   }
                 : undefined
             }
-            onChange={(newItemValue: any, key?: string, dataPath?: string) => {
+            onChange={(
+              newItemValue: any,
+              newDisplayValues: Record<string, any>,
+              key?: string,
+              dataPath?: string
+            ) => {
               const newValue = [...value];
 
               newValue[itemIndex] = newItemValue;
-              onChange(newValue, key, dataPath);
+              onChange(newValue, newDisplayValues, key, dataPath);
             }}
           ></Card>
         );
@@ -113,7 +122,8 @@ const ArrayCards = (props: Props) => {
                   defaultValue && typeof defaultValue === "object"
                     ? cloneDeep(defaultValue)
                     : defaultValue
-                )
+                ),
+                displayValues
               );
             }}
           >

--- a/src/_internal/molecules/ArrayGroups.tsx
+++ b/src/_internal/molecules/ArrayGroups.tsx
@@ -2,7 +2,7 @@ import { WidgetProps } from "./AutoForm/widget";
 import Group from "./Group";
 import { Type, Static } from "@sinclair/typebox";
 import { KitContext } from "../atoms/kit-context";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { css } from "@emotion/css";
 import Icon, {
   IconTypes,
@@ -53,6 +53,7 @@ const ArrayGroups = (props: Props) => {
   const kit = useContext(KitContext);
   const {
     value,
+    displayValues,
     spec,
     path,
     level,
@@ -97,15 +98,23 @@ const ArrayGroups = (props: Props) => {
             onRemove={
               value.length > (widgetOptions?.minLength || 0)
                 ? () => {
-                    onChange(value.filter((v, i) => i !== itemIndex));
+                    onChange(
+                      value.filter((v, i) => i !== itemIndex),
+                      displayValues
+                    );
                   }
                 : undefined
             }
-            onChange={(newItemValue: any, key?: string, dataPath?: string) => {
+            onChange={(
+              newItemValue: any,
+              newDisplayValues: Record<string, any>,
+              key?: string,
+              dataPath?: string
+            ) => {
               const newValue = [...value];
 
               newValue[itemIndex] = newItemValue;
-              onChange(newValue, key, dataPath);
+              onChange(newValue, newDisplayValues, key, dataPath);
             }}
           ></Group>
         );
@@ -131,7 +140,8 @@ const ArrayGroups = (props: Props) => {
                   defaultValue && typeof defaultValue === "object"
                     ? cloneDeep(defaultValue)
                     : defaultValue
-                )
+                ),
+                displayValues
               );
             }}
           >

--- a/src/_internal/molecules/ArrayItems.tsx
+++ b/src/_internal/molecules/ArrayItems.tsx
@@ -105,7 +105,6 @@ const ArrayItems = (props: Props) => {
               }}
             />
           </div>
-          ;
           {value.length > (widgetOptions?.minLength || 0) ? (
             <kit.Button
               className={CloseButtonStyle}

--- a/src/_internal/molecules/ArrayItems.tsx
+++ b/src/_internal/molecules/ArrayItems.tsx
@@ -53,6 +53,7 @@ const ArrayItems = (props: Props) => {
   const {
     spec,
     value = [],
+    displayValues,
     path,
     level,
     widgetOptions = {
@@ -92,20 +93,29 @@ const ArrayItems = (props: Props) => {
               path={path.concat(`.${itemIndex}`)}
               level={level + 1}
               widgetOptions={{}}
-              onChange={(newItemValue: any, key?: string, dataPath?: string) => {
+              onChange={(
+                newItemValue: any,
+                newDisplayValues: Record<string, any>,
+                key?: string,
+                dataPath?: string
+              ) => {
                 const newValue = [...value];
                 newValue[itemIndex] = newItemValue;
-                onChange(newValue, key, dataPath);
+                onChange(newValue, newDisplayValues, key, dataPath);
               }}
             />
           </div>
+          ;
           {value.length > (widgetOptions?.minLength || 0) ? (
             <kit.Button
               className={CloseButtonStyle}
               size="small"
               type="text"
               onClick={() => {
-                onChange(value.filter((_: any, i: number) => i !== itemIndex));
+                onChange(
+                  value.filter((_: any, i: number) => i !== itemIndex),
+                  displayValues
+                );
               }}
             >
               <CloseOutlined />
@@ -136,7 +146,8 @@ const ArrayItems = (props: Props) => {
                   defaultValue && typeof defaultValue
                     ? cloneDeep(defaultValue)
                     : defaultValue
-                )
+                ),
+                displayValues
               );
             }}
           >

--- a/src/_internal/molecules/AutoForm/ArrayField.tsx
+++ b/src/_internal/molecules/AutoForm/ArrayField.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 import { cloneDeep } from "lodash";
 
 const ArrayField: React.FC<WidgetProps> = (props) => {
-  const { spec, value = [], path, level, widgetOptions, onChange } = props;
+  const { spec, value = [] } = props;
   const itemSpec = Array.isArray(spec.items) ? spec.items[0] : spec.items;
 
   if (typeof itemSpec === "boolean" || !itemSpec) {
@@ -35,7 +35,7 @@ const ArrayField: React.FC<WidgetProps> = (props) => {
 export const AddToArrayField: React.FC<WidgetProps> = (props) => {
   const { t } = useTranslation();
   const kit = useContext(KitContext);
-  const { field, spec, value = [], onChange } = props;
+  const { displayValues, spec, value = [], onChange } = props;
   const itemSpec = Array.isArray(spec.items) ? spec.items[0] : spec.items;
 
   if (typeof itemSpec === "boolean" || !itemSpec) {
@@ -57,7 +57,8 @@ export const AddToArrayField: React.FC<WidgetProps> = (props) => {
               defaultValue && typeof defaultValue === "object"
                 ? cloneDeep(defaultValue)
                 : defaultValue
-            )
+            ),
+            displayValues
           );
         }}
       >

--- a/src/_internal/molecules/AutoForm/MultiSpecField.tsx
+++ b/src/_internal/molecules/AutoForm/MultiSpecField.tsx
@@ -32,7 +32,9 @@ const _Field: React.FC<
         path={path}
         level={level}
         value={value}
-        onChange={(newValue) => onChange(newValue)}
+        onChange={(newValue, newDisplayValues) =>
+          onChange(newValue, newDisplayValues)
+        }
       />
     </div>
   );

--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -199,6 +199,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
     slot,
     helperSlot,
     onChange,
+    onDisplayValuesChange,
   } = props;
   let { widgetOptions = {} } = props;
   const { title } = spec;
@@ -257,6 +258,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
       subKey={subKey}
       level={level}
       onChange={onChange}
+      onDisplayValuesChange={onDisplayValuesChange}
       step={step}
       stepElsRef={stepElsRef}
       layout={layout}
@@ -282,7 +284,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
         description={
           helperSlot?.(
             { path, ...(field || {}), index },
-            field?.helperText || '',
+            field?.helperText || "",
             `helper_${path}`
           ) || field?.helperText
         }

--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -190,6 +190,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
     path,
     step,
     value,
+    displayValues,
     stepElsRef,
     layout,
     subKey,
@@ -251,6 +252,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
       field={field}
       spec={spec}
       value={value}
+      displayValues={displayValues}
       path={path}
       subKey={subKey}
       level={level}

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -24,7 +24,13 @@ export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
   index?: number;
   error?: string | string[] | Record<string, string>;
   value: Value;
-  onChange: (newValue: Value, key?: string, dataPath?: string) => void;
+  displayValues: Record<string, any>;
+  onChange: (
+    newValue: Value,
+    displayValues: Record<string, any>,
+    key?: string,
+    dataPath?: string
+  ) => void;
   slot?: Function;
   helperSlot?: Function;
 };

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -31,6 +31,7 @@ export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
     key?: string,
     dataPath?: string
   ) => void;
+  onDisplayValuesChange: (displayValues: Record<string, any>) => void;
   slot?: Function;
   helperSlot?: Function;
 };

--- a/src/_internal/molecules/Input.tsx
+++ b/src/_internal/molecules/Input.tsx
@@ -16,6 +16,7 @@ export const OptionsSpec = Type.Object({
 type Props = WidgetProps<string, Static<typeof OptionsSpec>>;
 
 const Input = (props: Props) => {
+  const { displayValues } = props;
   const [input, setInput] = useState("");
   const kit = useContext(KitContext);
   const onChange = useCallback(
@@ -23,13 +24,14 @@ const Input = (props: Props) => {
       setInput(e.target.value);
       props.onChange(
         e.target.value,
+        displayValues,
         `${
           props.subKey ? `${props.subKey}${props.field?.key ? "-" : ""}` : ""
         }${props.field?.key || ""}`,
         props.path
       );
     },
-    [props.onChange, props.subKey, props.field]
+    [props, displayValues]
   );
 
   useEffect(() => {

--- a/src/_internal/molecules/InputNumber.tsx
+++ b/src/_internal/molecules/InputNumber.tsx
@@ -13,6 +13,7 @@ export const OptionsSpec = Type.Object({
 type Props = WidgetProps<number, Static<typeof OptionsSpec>>;
 
 const InputNumber = (props: Props) => {
+  const { displayValues } = props;
   const kit = useContext(KitContext);
   const [stringValue, setStringValue] = useState(props.value);
 
@@ -20,6 +21,7 @@ const InputNumber = (props: Props) => {
     (event, newValue) => {
       props.onChange(
         Number(newValue),
+        displayValues,
         `${
           props.subKey ? `${props.subKey}${props.field?.key ? "-" : ""}` : ""
         }${props.field?.key ?? ""}`,
@@ -27,7 +29,7 @@ const InputNumber = (props: Props) => {
       );
       setStringValue(newValue);
     },
-    [setStringValue, props]
+    [setStringValue, props, displayValues]
   );
 
   useEffect(() => {

--- a/src/_internal/molecules/K8sSelect.tsx
+++ b/src/_internal/molecules/K8sSelect.tsx
@@ -2,7 +2,7 @@ import { Select as AntdSelect } from "antd";
 import { Type, Static } from "@sinclair/typebox";
 import { WidgetProps } from "./AutoForm/widget";
 import { KitContext } from "../atoms/kit-context";
-import { useContext, useEffect, useState, useMemo } from "react";
+import React, { useContext, useEffect, useState, useMemo } from "react";
 import {
   KubeApi,
   UnstructuredList,
@@ -41,7 +41,7 @@ type Props = WidgetProps<string | string[], Static<typeof OptionsSpec>>;
 
 const K8sSelect = (props: Props) => {
   const kit = useContext(KitContext);
-  const { value, onChange, widgetOptions } = props;
+  const { value, displayValues, path, onChange, widgetOptions } = props;
   const {
     basePath,
     watchWsBasePath,
@@ -64,7 +64,7 @@ const K8sSelect = (props: Props) => {
         objectConstructor: {
           kind: "",
           apiBase: `${apiBase}/${resource}`,
-          namespace: namespace || '',
+          namespace: namespace || "",
         },
       }),
     [basePath, watchWsBasePath, apiBase, resource, namespace]
@@ -74,7 +74,7 @@ const K8sSelect = (props: Props) => {
     (async function () {
       const result = await api.list({
         query: {
-          namespace: namespace || '',
+          namespace: namespace || "",
           fieldSelector: compact([fieldSelector]).join(","),
         },
       });
@@ -85,16 +85,20 @@ const K8sSelect = (props: Props) => {
           value: get(item, valuePath || ""),
         }))
       );
-    })();
-  }, [api, fieldSelector]);
+    })().catch(() => {});
+  }, [api, fieldSelector, namespace, valuePath]);
 
   return (
     <kit.Select
       disabled={disabled}
       value={(value || "") as any}
-      onChange={(value) =>
+      onChange={(value, option) =>
         onChange(
           value,
+          {
+            ...displayValues,
+            [path]: option.label,
+          },
           `${
             props.subKey ? `${props.subKey}${props.field?.key ? "-" : ""}` : ""
           }${props.field?.key || ""}`,

--- a/src/_internal/molecules/Select.tsx
+++ b/src/_internal/molecules/Select.tsx
@@ -2,7 +2,7 @@ import { Select as AntdSelect } from "antd";
 import { Type, Static } from "@sinclair/typebox";
 import { WidgetProps } from "./AutoForm/widget";
 import { KitContext } from "../atoms/kit-context";
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { styled } from "@linaria/react";
 
 const OptionWrapper = styled.div`
@@ -36,8 +36,28 @@ type Props = WidgetProps<string | string[], Static<typeof OptionsSpec>>;
 
 const Select = (props: Props) => {
   const kit = useContext(KitContext);
-  const { value, onChange, widgetOptions, displayValues, path } = props;
+  const {
+    value,
+    onChange,
+    onDisplayValuesChange,
+    widgetOptions,
+    displayValues,
+    path,
+  } = props;
   const { options = [], disabled } = widgetOptions || { options: [] };
+
+  useEffect(() => {
+    if (value) {
+      const selectedOption = options.find((option) => option.value === value);
+
+      if (selectedOption) {
+        onDisplayValuesChange({
+          ...displayValues,
+          [path]: selectedOption.label,
+        });
+      }
+    }
+  }, []);
 
   return (
     <kit.Select

--- a/src/_internal/molecules/Select.tsx
+++ b/src/_internal/molecules/Select.tsx
@@ -2,7 +2,7 @@ import { Select as AntdSelect } from "antd";
 import { Type, Static } from "@sinclair/typebox";
 import { WidgetProps } from "./AutoForm/widget";
 import { KitContext } from "../atoms/kit-context";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { styled } from "@linaria/react";
 
 const OptionWrapper = styled.div`
@@ -36,16 +36,20 @@ type Props = WidgetProps<string | string[], Static<typeof OptionsSpec>>;
 
 const Select = (props: Props) => {
   const kit = useContext(KitContext);
-  const { value, onChange, widgetOptions } = props;
+  const { value, onChange, widgetOptions, displayValues, path } = props;
   const { options = [], disabled } = widgetOptions || { options: [] };
 
   return (
     <kit.Select
       disabled={disabled}
       value={(value || "") as any}
-      onChange={(value) =>
+      onChange={(value, option) =>
         onChange(
           value,
+          {
+            ...displayValues,
+            [path]: option.label,
+          },
           `${
             props.subKey ? `${props.subKey}${props.field?.key ? "-" : ""}` : ""
           }${props.field?.key || ""}`,

--- a/src/_internal/molecules/Switch.tsx
+++ b/src/_internal/molecules/Switch.tsx
@@ -1,6 +1,6 @@
 import { Type, Static } from "@sinclair/typebox";
 import { WidgetProps } from "./AutoForm/widget";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { KitContext } from "../atoms/kit-context";
 
 export const OptionsSpec = Type.Object({
@@ -11,6 +11,7 @@ export const OptionsSpec = Type.Object({
 type Props = WidgetProps<boolean, Static<typeof OptionsSpec>>;
 
 const Switch = (props: Props) => {
+  const { displayValues } = props;
   const kit = useContext(KitContext);
 
   return (
@@ -19,6 +20,7 @@ const Switch = (props: Props) => {
       onChange={(value) =>
         props.onChange(
           value,
+          displayValues,
           `${
             props.subKey ? `${props.subKey}${props.field?.key ? "-" : ""}` : ""
           }${props.field?.key || ""}`,

--- a/src/_internal/molecules/Textarea.tsx
+++ b/src/_internal/molecules/Textarea.tsx
@@ -1,13 +1,14 @@
 import { Input } from "antd";
 import { Type, Static } from "@sinclair/typebox";
 import { WidgetProps } from "./AutoForm/widget";
+import React from "react";
 
 export const OptionsSpec = Type.Object({});
 
 type Props = WidgetProps<string, Static<typeof OptionsSpec>>;
 
 const Textarea = (props: Props) => {
-  const { value, onChange } = props;
+  const { value, onChange, displayValues } = props;
 
   return (
     <Input.TextArea
@@ -15,7 +16,10 @@ const Textarea = (props: Props) => {
       onChange={(event) =>
         onChange(
           event.currentTarget.value,
-          `${props.subKey ? `${props.subKey}${props.field?.key ? '-' : ''}` : ""}${props.field?.key || ""}`,
+          displayValues,
+          `${
+            props.subKey ? `${props.subKey}${props.field?.key ? "-" : ""}` : ""
+          }${props.field?.key || ""}`,
           props.path
         )
       }

--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
@@ -56,6 +56,7 @@ export type KubectlApplyFormProps = {
   };
   values: any[];
   defaultValues: any[];
+  displayValues: Record<string, any>;
   error?: string;
   errorDetail?: {
     title: string;
@@ -74,7 +75,12 @@ export type KubectlApplyFormProps = {
     fallback: React.ReactNode,
     slotKey: string
   ) => React.ReactNode;
-  onChange: (values: any[], key?: string, dataPath?: string) => void;
+  onChange: (
+    values: any[],
+    displayValues: Record<string, any>,
+    key?: string,
+    dataPath?: string
+  ) => void;
   onNextStep?: (values: any[]) => void;
   onSubmit?: (values: any[]) => void;
   onCancel?: () => void;
@@ -92,6 +98,7 @@ const KubectlApplyForm = React.forwardRef<
       uiConfig,
       values,
       defaultValues,
+      displayValues,
       error,
       errorDetail,
       submitting,
@@ -113,7 +120,7 @@ const KubectlApplyForm = React.forwardRef<
     const kit = useContext(KitContext);
     // wizard
     const { layout, title } = uiConfig;
-    const summaryInfo = useSummary(layout, values);
+    const summaryInfo = useSummary(layout, values, displayValues);
 
     function getComponent(f: TransformedField) {
       const [indexStr, path] = f.path.split(/\.(.*)/s);
@@ -133,12 +140,18 @@ const KubectlApplyForm = React.forwardRef<
           path={f.dataPath}
           stepElsRef={{}}
           value={f.value}
+          displayValues={displayValues}
           slot={getSlot}
           helperSlot={getHelperSlot}
-          onChange={(newValue: any, key?: string, dataPath?: string) => {
+          onChange={(
+            newValue: any,
+            displayValue: any,
+            key?: string,
+            dataPath?: string
+          ) => {
             const valuesSlice = [...values];
             set(valuesSlice, f.dataPath, newValue);
-            onChange(valuesSlice, key, dataPath);
+            onChange(valuesSlice, displayValue, key, dataPath);
           }}
         />
       );
@@ -214,7 +227,7 @@ const KubectlApplyForm = React.forwardRef<
                     </div>
                     <div className="wizard-footer-btn-group">
                       <kit.Button
-                        type={`quiet` as unknown as ButtonType}
+                        type={"quiet" as unknown as ButtonType}
                         onClick={() => {
                           onCancel?.();
                         }}
@@ -347,7 +360,7 @@ const KubectlApplyForm = React.forwardRef<
                     </div>
                     <div className="wizard-footer-btn-group">
                       <kit.Button
-                        type={`quiet` as unknown as ButtonType}
+                        type={"quiet" as unknown as ButtonType}
                         onClick={() => {
                           onCancel?.();
                         }}
@@ -418,7 +431,7 @@ const KubectlApplyForm = React.forwardRef<
               .map((v) => dump(v, { noRefs: true }))
               .join("---\n")}
             onBlur={(newValue) => {
-              onChange(yaml.loadAll(newValue));
+              onChange(yaml.loadAll(newValue), displayValues);
             }}
             language="yaml"
           />

--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.tsx
@@ -81,6 +81,7 @@ export type KubectlApplyFormProps = {
     key?: string,
     dataPath?: string
   ) => void;
+  onDisplayValuesChange: (displayValues: Record<string, any>) => void;
   onNextStep?: (values: any[]) => void;
   onSubmit?: (values: any[]) => void;
   onCancel?: () => void;
@@ -103,6 +104,7 @@ const KubectlApplyForm = React.forwardRef<
       errorDetail,
       submitting,
       onChange,
+      onDisplayValuesChange,
       getSlot,
       getHelperSlot,
       step,
@@ -152,6 +154,9 @@ const KubectlApplyForm = React.forwardRef<
             const valuesSlice = [...values];
             set(valuesSlice, f.dataPath, newValue);
             onChange(valuesSlice, displayValue, key, dataPath);
+          }}
+          onDisplayValuesChange={(displayValues: Record<string, any>) => {
+            onDisplayValuesChange(displayValues);
           }}
         />
       );

--- a/src/_internal/organisms/KubectlApplyForm/useSummary.tsx
+++ b/src/_internal/organisms/KubectlApplyForm/useSummary.tsx
@@ -8,23 +8,38 @@ import type {
 import { Layout, Field } from "./type";
 import { get } from "lodash";
 
-function getValueByPath(formData: Record<string, any>, path: string) {
+function getValueByPath(
+  formData: Record<string, any>,
+  displayValues: Record<string, any>,
+  path: string,
+  fullPath: string
+): unknown {
   if (path.includes("$add") || path.includes("$i")) {
     if (path.includes(".$i.")) {
       // has sub path
       const [arrayPath, subPath] = path.split(".$i.");
-      const array = get(formData, arrayPath);
+      const array: any[] =
+        displayValues[fullPath] || get(formData, arrayPath) || [];
 
-      return array.map((item: any) => getValueByPath(item, subPath));
+      return array.map((item: any) =>
+        getValueByPath(
+          item,
+          displayValues,
+          subPath,
+          fullPath ? `${fullPath}.${subPath}` : subPath
+        )
+      );
     }
   } else {
-    return get(formData, path);
+    return displayValues[fullPath] || get(formData, path);
   }
 }
 
 function getListItems(
   fields: Field[],
-  formData: Record<string, any>
+  formData: Record<string, any>,
+  displayValues: Record<string, any>,
+  parentPath: string
 ): (Item | Object | SubHeading | Label)[] {
   return fields
     .map((field) => {
@@ -37,14 +52,21 @@ function getListItems(
         });
       }
 
-      const path = field.path.replace(/(.\$add)|(.\$i)/g, (substring)=> {
-        if (substring === '.$add') {
-          return ''; 
+      const path = field.path.replace(/(.\$add)|(.\$i)/g, (substring) => {
+        if (substring === ".$add") {
+          // 0.spec.topology.workers.$add -> 0.spec.topology.workers
+          return "";
         } else {
-          return '.0';
+          // 0.spec.topology.workers.$i.name -> 0.spec.topology.workers.0.name
+          return ".0";
         }
       });
-      const value = getValueByPath(formData, path);
+      const value: unknown = getValueByPath(
+        formData,
+        displayValues,
+        path,
+        parentPath ? `${parentPath}.${path}` : path
+      );
 
       if (value instanceof Array) {
         if (typeof value[0] !== "object") {
@@ -59,14 +81,21 @@ function getListItems(
           if (item && typeof item === "object") {
             items.push({
               type: "Label" as const,
-              label: field.widgetOptions?.title + ' ' + (index + 1),
+              label: `${field.widgetOptions?.title || "Group"} ${index + 1}`,
             });
             items.push({
               type: "Object" as const,
               icon: field.widgetOptions?.icon,
               label: field.label,
               items: field.fields?.length
-                ? (getListItems(field.fields, item) as Item[])
+                ? (getListItems(
+                    field.fields,
+                    item,
+                    displayValues,
+                    parentPath
+                      ? `${parentPath}.${path}.${index}`
+                      : `${path}.${index}`
+                  ) as Item[])
                 : Object.keys(item).map((key) => ({
                     type: "Item" as const,
                     label: key,
@@ -87,18 +116,23 @@ function getListItems(
           label: field.label || field.widgetOptions?.title,
           icon: field.widgetOptions?.icon,
           items: field.fields?.length
-            ? (getListItems(field.fields, value) as Item[])
+            ? (getListItems(
+                field.fields,
+                value,
+                displayValues,
+                parentPath ? `${parentPath}.${path}` : path
+              ) as Item[])
             : Object.keys(value).map((key) => ({
                 type: "Item" as const,
                 label: key,
-                value: JSON.stringify(value[key]),
+                value: JSON.stringify(value[key as keyof typeof value]),
               })),
         });
       } else if (field.label) {
         items.push({
           type: "Item" as const,
           label: field.label,
-          value,
+          value: value as string | boolean | number,
         });
       }
 
@@ -107,7 +141,11 @@ function getListItems(
     .flat();
 }
 
-function useSummary(formConfig: Layout, formData: Record<string, any>) {
+function useSummary(
+  formConfig: Layout,
+  formData: Record<string, any>,
+  displayValues: Record<string, any>
+) {
   if (formConfig.type === "tabs" || formConfig.type === "wizard") {
     let categories: {
       title: string;
@@ -122,7 +160,7 @@ function useSummary(formConfig: Layout, formData: Record<string, any>) {
 
     const groups: Group[] = categories.map((group) => ({
       title: group.title,
-      children: getListItems(group.fields, formData),
+      children: getListItems(group.fields, formData, displayValues, ""),
     }));
 
     return {
@@ -130,7 +168,7 @@ function useSummary(formConfig: Layout, formData: Record<string, any>) {
     };
   } else {
     return {
-      items: getListItems(formConfig.fields, formData),
+      items: getListItems(formConfig.fields, formData, displayValues, ""),
     };
   }
 }

--- a/src/editor/widgets/k8s/common/FieldCustomComponentWidget.tsx
+++ b/src/editor/widgets/k8s/common/FieldCustomComponentWidget.tsx
@@ -141,6 +141,7 @@ const FieldCustomComponentWidget =
                               ? `${parentPath}.${fieldPath}`
                               : fieldPath,
                             value: `{{${newComponentId}.value}}`,
+                            displayValue: `{{${newComponentId}.displayValue}}`,
                           },
                         },
                         wait: {

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -1,7 +1,7 @@
 import { Type, Static } from "@sinclair/typebox";
 import { implementRuntimeComponent } from "@sunmao-ui/runtime";
 import { PRESET_PROPERTY_CATEGORY, StringUnion } from "@sunmao-ui/shared";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { generateFromSchema } from "../../_internal/utils/schema";
 import merge from "lodash/merge";
 import set from "lodash/set";
@@ -122,7 +122,10 @@ export const UiConfigSpec = Type.Object({
           fields: Type.Array(UiConfigFieldSpec, {
             title: "Fields",
             widget: "core/v1/array",
-            widgetOptions: { displayedKeys: ["path", "label"], appendToBody: true },
+            widgetOptions: {
+              displayedKeys: ["path", "label"],
+              appendToBody: true,
+            },
           }),
         }),
         {
@@ -143,7 +146,10 @@ export const UiConfigSpec = Type.Object({
           fields: Type.Array(UiConfigFieldSpec, {
             title: "Fields",
             widget: "core/v1/array",
-            widgetOptions: { displayedKeys: ["path", "label"], appendToBody: true },
+            widgetOptions: {
+              displayedKeys: ["path", "label"],
+              appendToBody: true,
+            },
           }),
           disabled: Type.Boolean({ title: "Disabled" }),
           prevText: Type.String({ title: "Previous text" }),
@@ -222,6 +228,7 @@ const KubectlApplyFormProps = Type.Object({
 
 const KubectlApplyFormState = Type.Object({
   value: Type.Any(),
+  displayValue: Type.Any(),
   latestChangedKey: Type.String(),
   latestChangedPath: Type.String(),
   step: Type.Number(),
@@ -262,6 +269,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
       setField: Type.Object({
         fieldPath: Type.String(),
         value: Type.Any(),
+        displayValue: Type.Any(),
       }),
       nextStep: Type.Object({}),
       apply: Type.Object({}),
@@ -312,19 +320,26 @@ export const KubectlApplyForm = implementRuntimeComponent({
       mergeState({ value: initValues });
       return initValues;
     });
+    const [displayValues, setDisplayValues] = useState<Record<string, any>>([]);
     useEffect(() => {
       subscribeMethods({
-        setField({ fieldPath, value: fieldValue }) {
+        setField({ fieldPath, value: fieldValue, displayValue }) {
           const finalFieldValue =
             fieldValue && typeof fieldValue === "object"
               ? cloneDeep(fieldValue)
               : fieldValue;
           const newValues = set(values, fieldPath, finalFieldValue);
+          const newDisplayValues = {
+            ...displayValues,
+            [fieldPath]: displayValue,
+          };
 
           mergeState({
             value: newValues,
+            displayValue: newDisplayValues,
           });
           setValues([...newValues]);
+          setDisplayValues(newDisplayValues);
         },
         nextStep() {
           mergeState({
@@ -332,7 +347,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
           });
           setStep(step + 1);
         },
-        async apply() {
+        apply() {
           try {
             const sdk = new KubeSdk({
               basePath,
@@ -340,32 +355,33 @@ export const KubectlApplyForm = implementRuntimeComponent({
             mergeState({
               loading: true,
             });
-            await sdk.applyYaml(values);
+            sdk.applyYaml(values).catch((error: { response: Response }) => {
+              if (error.response) {
+                error.response
+                  .clone()
+                  .json()
+                  .then((result: any) => {
+                    mergeState({
+                      error: {
+                        ...error,
+                        responseJsonBody: result,
+                      },
+                    });
+                  })
+                  .catch(() => {});
+              }
+            });
+
             mergeState({
               loading: false,
             });
             callbackMap?.onApplySuccess?.();
-          } catch (error: any) {
-            if (error.response) {
-              error.response
-                .clone()
-                .json()
-                .then((result: any) => {
-                  mergeState({
-                    error: {
-                      ...error,
-                      responseJsonBody: result,
-                    },
-                  });
-                });
-            }
+          } catch (error) {}
 
-            mergeState({
-              loading: false,
-              error,
-            });
-            callbackMap?.onApplyFail?.();
-          }
+          mergeState({
+            loading: false,
+          });
+          callbackMap?.onApplyFail?.();
         },
         clearError() {
           mergeState({
@@ -373,7 +389,15 @@ export const KubectlApplyForm = implementRuntimeComponent({
           });
         },
       });
-    }, [step, subscribeMethods, mergeState, values, callbackMap]);
+    }, [
+      step,
+      subscribeMethods,
+      mergeState,
+      values,
+      callbackMap,
+      basePath,
+      displayValues,
+    ]);
 
     return (
       <_KubectlApplyForm
@@ -384,6 +408,7 @@ export const KubectlApplyForm = implementRuntimeComponent({
         schemas={formConfig.schemas}
         uiConfig={formConfig.uiConfig}
         values={values}
+        displayValues={displayValues}
         error={error}
         errorDetail={errorDetail}
         submitting={submitting}
@@ -395,10 +420,17 @@ export const KubectlApplyForm = implementRuntimeComponent({
           setStep(step);
         }}
         defaultValues={formConfig.defaultValues}
-        onChange={(newValues: any, key?: string, dataPath?: string) => {
+        onChange={(
+          newValues: any,
+          displayValues: Record<string, any>,
+          key?: string,
+          dataPath?: string
+        ) => {
           setValues(newValues);
+          setDisplayValues(displayValues);
           mergeState({
             value: newValues,
+            displayValue: displayValues,
             latestChangedKey: key,
             latestChangedPath: dataPath,
           });

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -1,7 +1,7 @@
 import { Type, Static } from "@sinclair/typebox";
 import { implementRuntimeComponent } from "@sunmao-ui/runtime";
 import { PRESET_PROPERTY_CATEGORY, StringUnion } from "@sunmao-ui/shared";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { generateFromSchema } from "../../_internal/utils/schema";
 import merge from "lodash/merge";
 import set from "lodash/set";
@@ -271,6 +271,10 @@ export const KubectlApplyForm = implementRuntimeComponent({
         value: Type.Any(),
         displayValue: Type.Any(),
       }),
+      setDisplayValue: Type.Object({
+        fieldPath: Type.String(),
+        displayValue: Type.Any(),
+      }),
       nextStep: Type.Object({}),
       apply: Type.Object({}),
       clearError: Type.Object({}),
@@ -320,7 +324,9 @@ export const KubectlApplyForm = implementRuntimeComponent({
       mergeState({ value: initValues });
       return initValues;
     });
-    const [displayValues, setDisplayValues] = useState<Record<string, any>>([]);
+    const [displayValues, setDisplayValues] = useState<Record<string, any>>({});
+    const updatedDisplayValuesRef = useRef<Record<string, any>>({});
+
     useEffect(() => {
       subscribeMethods({
         setField({ fieldPath, value: fieldValue, displayValue }) {
@@ -329,17 +335,29 @@ export const KubectlApplyForm = implementRuntimeComponent({
               ? cloneDeep(fieldValue)
               : fieldValue;
           const newValues = set(values, fieldPath, finalFieldValue);
-          const newDisplayValues = {
+          updatedDisplayValuesRef.current = {
+            ...updatedDisplayValuesRef.current,
             ...displayValues,
             [fieldPath]: displayValue,
           };
 
           mergeState({
             value: newValues,
-            displayValue: newDisplayValues,
+            displayValue: updatedDisplayValuesRef.current,
           });
           setValues([...newValues]);
-          setDisplayValues(newDisplayValues);
+          setDisplayValues(updatedDisplayValuesRef.current);
+        },
+        setDisplayValue({ fieldPath, displayValue }) {
+          updatedDisplayValuesRef.current = {
+            ...updatedDisplayValuesRef.current,
+            ...displayValues,
+            [fieldPath]: displayValue,
+          };
+          mergeState({
+            displayValue: updatedDisplayValuesRef.current,
+          });
+          setDisplayValues(updatedDisplayValuesRef.current);
         },
         nextStep() {
           mergeState({
@@ -398,6 +416,9 @@ export const KubectlApplyForm = implementRuntimeComponent({
       basePath,
       displayValues,
     ]);
+    useEffect(() => {
+      updatedDisplayValuesRef.current = {};
+    }, [displayValues]);
 
     return (
       <_KubectlApplyForm
@@ -426,15 +447,29 @@ export const KubectlApplyForm = implementRuntimeComponent({
           key?: string,
           dataPath?: string
         ) => {
+          updatedDisplayValuesRef.current = {
+            ...updatedDisplayValuesRef.current,
+            ...displayValues,
+          };
           setValues(newValues);
-          setDisplayValues(displayValues);
+          setDisplayValues(updatedDisplayValuesRef.current);
           mergeState({
             value: newValues,
-            displayValue: displayValues,
+            displayValue: updatedDisplayValuesRef.current,
             latestChangedKey: key,
             latestChangedPath: dataPath,
           });
           callbackMap?.onChange?.();
+        }}
+        onDisplayValuesChange={(displayValues: Record<string, any>) => {
+          updatedDisplayValuesRef.current = {
+            ...updatedDisplayValuesRef.current,
+            ...displayValues,
+          };
+          setDisplayValues(updatedDisplayValuesRef.current);
+          mergeState({
+            displayValue: updatedDisplayValuesRef.current,
+          });
         }}
         onNextStep={callbackMap?.onNextStep}
         onSubmit={callbackMap?.onSubmit}

--- a/src/sunmao/components/Select.tsx
+++ b/src/sunmao/components/Select.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { implementRuntimeComponent } from "@sunmao-ui/runtime";
 import { css } from "@emotion/css";
 import { Type } from "@sinclair/typebox";
 import { Select as BaseSelect } from "antd";
 
 const SelectProps = Type.Object({
-  defaultValue: Type.Any(),
+  defaultValue: Type.String(),
   options: Type.Array(
     Type.Object({
       text: Type.String(),
@@ -16,6 +16,7 @@ const SelectProps = Type.Object({
 
 const SelectState = Type.Object({
   value: Type.Any(),
+  selectedOption: Type.Any(),
 });
 
 export const Select = implementRuntimeComponent({
@@ -63,17 +64,17 @@ export const Select = implementRuntimeComponent({
     mergeState,
     subscribeMethods,
   }) => {
-    const [value, setValue] = useState(defaultValue);
+    const [value, setValue] = useState<string>(defaultValue);
     useEffect(() => {
       mergeState({
         value,
       });
-    }, [value]);
+    }, [value, mergeState]);
     useEffect(() => {
       subscribeMethods({
         setValue,
       });
-    }, []);
+    }, [subscribeMethods]);
 
     return (
       <BaseSelect
@@ -82,10 +83,11 @@ export const Select = implementRuntimeComponent({
           ${customStyle?.select}
         `}
         value={value}
-        onChange={(newV) => {
+        onChange={(newV: string, option) => {
           setValue(newV);
           mergeState({
             value: newV,
+            selectedOption: option,
           });
           callbackMap?.onChange?.();
         }}


### PR DESCRIPTION
给 KAF 添加 `displayValues` state，用于存储表单的展示值（比如 Select 选中项的 Label），给 Summary List 展示表单的值时可以展示其他文本而非原始值。

## 数据结构
`displayValues` 是一个以属性路径为键，展示值为其值的 Map，比如：

```js
{
  displayValues: {
    '0.spec.topology.controlPlane.replicas': '1 个'
  }
}
```

## 设置值
在 KAF 中，可以有两种方式使用表单组件：Widget 和 自定义组件。它们通过不同的方式来设置展示值。

### Widget
在 Widget 中，在 `onChange` 中新增一个 `displayValues` 参数用于设置展示值，比如 Select：
```js
function Select(props) {
  return <Select onChange={(value, option) =>
        props.onChange(
          value,
          {
            ...props.displayValues,
            [props.path]: option.label,
          },
          ...
        )
      } />
}
```

### 自定义组件
自定义组件可通过调用 KAF `setField` 来同时设置值和展示值：
```js
            {
              "type": "core/v1/event",
              "properties": {
                "handlers": [
                  {
                    "type": "onChange",
                    "componentId": "workload_cluster_form",
                    "method": {
                      "name": "setField",
                      "parameters": {
                        "fieldPath": "0.spec.cloudProvider.cloudtower.elfCluster",
                        "value": "{{workload_cluster_form_select_056769.value}}",
                        "displayValue": "{{workload_cluster_form_select_056769.selectedOption.children}}"
                      }
                    },
                    "wait": {
                      "type": "debounce",
                      "time": 0
                    },
                    "disabled": false
                  }
                ]
              }
            },
```

### 其他场景
然后还存在设置表单默认值和表单联动的场景，在这些场景中设置值的一方未必能获取到对应组件的数据来设置默认的展示值（比如在多步骤表单中组件非当前步骤的表单项不会渲染），这时就需要用户修改下表单的实现，在单独的地方设置下展示值。可以这样做来实现这些场景的需求：
1. 将数据源提取到整个 KAF 都能获取到的地方
2. 在 KAF `onMount` 或者数据返回时，根据 KAF 的实际值来找到对应的展示值来进行设置

## Summary List 处理展示值
```js
function getValueByPath(
  formData: Record<string, any>,
  displayValues: Record<string, any>,
  path: string,
  fullPath: string
) {
  ...
  // 优先获取展示值
  return displayValues[fullPath] || get(formData, path);
}
```