### PR TITLE
Feat/kaf summary list

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "kubernetes-types": "1.21.0-beta.1",
     "ky": "^0.30.0",
     "lodash": "^4.17.21",
+    "mitt": "^3.0.0",
     "monaco-editor": "^0.33.0",
     "rc-util": "^5.25.2",
     "react-use": "^17.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,7 @@ specifiers:
   ky: ^0.30.0
   less: ^3.10.3
   lodash: ^4.17.21
+  mitt: ^3.0.0
   mobx: ^6.6.1
   mobx-react-lite: ^3.4.0
   monaco-editor: ^0.33.0
@@ -82,6 +83,7 @@ dependencies:
   kubernetes-types: 1.21.0-beta.1
   ky: 0.30.0
   lodash: 4.17.21
+  mitt: 3.0.0
   monaco-editor: 0.33.0
   rc-util: 5.25.2_sfoxds7t5ydpegc3knd667wn6m
   react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
@@ -6353,7 +6355,6 @@ packages:
 
   /mitt/3.0.0:
     resolution: {integrity: sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==}
-    dev: true
 
   /mkdirp/1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}

--- a/src/_internal/atoms/themes/CloudTower/components/SummaryList.tsx
+++ b/src/_internal/atoms/themes/CloudTower/components/SummaryList.tsx
@@ -13,9 +13,11 @@ const { Panel } = Collapse;
 const SummaryListWrapper = styled.div`
   min-width: 190px;
   min-height: 408px;
-  overflow: auto;
+  max-height: 100%;
   border: 1px solid rgba(211, 218, 235, 0.6);
   border-radius: 6px;
+  display: flex;
+  flex-direction: column;
 `;
 
 const SummaryListTitle = styled.h3`
@@ -58,7 +60,7 @@ const SummaryCollapseStyle = css`
 `;
 
 const SummaryListBody = styled.div`
-  max-height: calc(100vh - 220px);
+  flex: 1;
   overflow: auto;
 `;
 

--- a/src/_internal/molecules/ArrayCards.tsx
+++ b/src/_internal/molecules/ArrayCards.tsx
@@ -2,7 +2,7 @@ import { WidgetProps } from "./AutoForm/widget";
 import Card from "./Card";
 import { Type, Static } from "@sinclair/typebox";
 import { KitContext } from "../atoms/kit-context";
-import React, { useContext } from "react";
+import React, { useContext, useCallback, useEffect, useMemo } from "react";
 import { css } from "@emotion/css";
 import Icon, {
   IconTypes,
@@ -10,7 +10,7 @@ import Icon, {
 import { generateFromSchema } from "../utils/schema";
 import { JSONSchema7 } from "json-schema";
 import { useTranslation } from "react-i18next";
-import { cloneDeep } from "lodash";
+import { cloneDeep, set } from "lodash";
 
 const AddedButtonStyle = css``;
 
@@ -40,6 +40,8 @@ const ArrayCards = (props: Props) => {
   const { t } = useTranslation();
   const kit = useContext(KitContext);
   const {
+    services,
+    field,
     value,
     displayValues,
     spec,
@@ -56,6 +58,45 @@ const ArrayCards = (props: Props) => {
   } = props;
   const itemSpec = Array.isArray(spec.items) ? spec.items[0] : spec.items;
   const errorInfo = props.field?.error || props.error;
+  const removable = useMemo(
+    () => value.length > (widgetOptions?.minLength || 0),
+    [value.length, widgetOptions?.minLength]
+  );
+
+  const remove = useCallback(
+    (index: number) => {
+      onChange(
+        value.filter((v, i) => i !== index),
+        displayValues
+      );
+    },
+    [onChange, value, displayValues]
+  );
+  const handleRemoveEvent = useCallback(
+    (eventData: { fieldKey: string; index: number }) => {
+      if (field?.key === eventData.fieldKey) {
+        remove(eventData.index);
+      }
+    },
+    [field?.key, remove]
+  );
+
+  useEffect(() => {
+    const store = set(
+      services.store,
+      `summary.removableMap.${field?.key || ""}`,
+      removable
+    );
+
+    services.setStore({ ...store });
+  }, [field?.key, removable]);
+  useEffect(() => {
+    services.event.on("remove", handleRemoveEvent);
+
+    return () => {
+      services.event.off("remove", handleRemoveEvent);
+    };
+  }, [handleRemoveEvent, services.event]);
 
   return (
     <>
@@ -78,12 +119,9 @@ const ArrayCards = (props: Props) => {
             path={path.concat(`.${itemIndex}`)}
             level={level + 1}
             onRemove={
-              value.length > (widgetOptions?.minLength || 0)
+              removable
                 ? () => {
-                    onChange(
-                      value.filter((v, i) => i !== itemIndex),
-                      displayValues
-                    );
+                    remove(itemIndex);
                   }
                 : undefined
             }

--- a/src/_internal/molecules/AutoForm/SpecField.tsx
+++ b/src/_internal/molecules/AutoForm/SpecField.tsx
@@ -184,6 +184,7 @@ type SpecFieldProps = WidgetProps & {
 
 const SpecField: React.FC<SpecFieldProps> = (props) => {
   const {
+    services,
     basePath,
     field,
     spec,
@@ -250,6 +251,7 @@ const SpecField: React.FC<SpecFieldProps> = (props) => {
 
   const FieldComponent = (
     <Component
+      services={services}
       widgetOptions={widgetOptions}
       error={typeof error !== "string" ? error : undefined}
       field={field}

--- a/src/_internal/molecules/AutoForm/widget.ts
+++ b/src/_internal/molecules/AutoForm/widget.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from "json-schema";
-import type { Field } from "../../organisms/KubectlApplyForm/type";
+import type { Field, Services } from "../../organisms/KubectlApplyForm/type";
 
 type WidgetOptions = Partial<{
   displayLabel: boolean;
@@ -8,6 +8,7 @@ type WidgetOptions = Partial<{
 }>;
 
 export type WidgetProps<Value = any, WidgetOptions = Record<string, any>> = {
+  services: Services;
   basePath: string;
   field?: Field;
   spec: JSONSchema7;

--- a/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.style.ts
+++ b/src/_internal/organisms/KubectlApplyForm/KubectlApplyForm.style.ts
@@ -40,6 +40,7 @@ export const WizardBodyStyle = css`
 
   .right {
     padding-left: 44px;
+    height: calc(100% - 40px);
   }
 
   .middle {
@@ -62,7 +63,7 @@ export const WizardBodyStyle = css`
       width: 100%;
       margin: 0 12px;
       margin-bottom: 16px;
-      
+
       &-title {
         margin-bottom: 8px;
       }

--- a/src/_internal/organisms/KubectlApplyForm/type.ts
+++ b/src/_internal/organisms/KubectlApplyForm/type.ts
@@ -1,3 +1,5 @@
+import { Emitter } from "mitt";
+
 export type Field = {
   fields?: Field[];
   path: string;
@@ -16,6 +18,13 @@ export type Field = {
   col?: number;
   splitLine?: boolean;
   defaultValue?: any;
+  summaryConfig?: {
+    type?: "auto" | "item";
+    label?: string;
+    value?: string;
+    icon?: string;
+    hidden?: boolean;
+  };
 };
 
 export type TransformedField = Field & { dataPath: string; value: any };
@@ -42,3 +51,22 @@ export type Layout =
         nextText?: string;
       }[];
     };
+
+export type Events = {
+  remove: {
+    index: number;
+    fieldKey: string;
+  };
+};
+
+export type Store = {
+  summary: {
+    removableMap: Record<string, boolean>;
+  };
+};
+
+export type Services = {
+  event: Emitter<Events>;
+  store: Store;
+  setStore: (store: Store) => void;
+};

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -69,6 +69,13 @@ const UiConfigFieldSpecProperties = {
       },
     ],
   }),
+  summaryConfig: Type.Object({
+    type: StringUnion(["auto", "item"]),
+    label: Type.String(),
+    value: Type.String(),
+    icon: Type.String(),
+    hidden: Type.Boolean(),
+  }),
 };
 const UiConfigFieldSpec = Type.Object(
   {
@@ -95,16 +102,9 @@ export const UiConfigSpec = Type.Object({
   }),
   layout: Type.Object(
     {
-      type: Type.KeyOf(
-        Type.Object({
-          simple: Type.Boolean(),
-          tabs: Type.Boolean(),
-          wizard: Type.Boolean(),
-        }),
-        {
-          title: "Type",
-        }
-      ),
+      type: StringUnion(["simple", "tabs", "wizard"], {
+        title: "Type",
+      }),
       fields: Type.Array(UiConfigFieldSpec, {
         title: "Fields",
         widget: "core/v1/array",

--- a/src/sunmao/components/KubectlApplyForm.tsx
+++ b/src/sunmao/components/KubectlApplyForm.tsx
@@ -6,6 +6,7 @@ import { generateFromSchema } from "../../_internal/utils/schema";
 import merge from "lodash/merge";
 import set from "lodash/set";
 import cloneDeep from "lodash/cloneDeep";
+import isEqual from "lodash/isEqual";
 import _KubectlApplyForm from "../../_internal/organisms/KubectlApplyForm/KubectlApplyForm";
 import { css } from "@emotion/css";
 import {
@@ -417,7 +418,9 @@ export const KubectlApplyForm = implementRuntimeComponent({
       displayValues,
     ]);
     useEffect(() => {
-      updatedDisplayValuesRef.current = {};
+      if (isEqual(updatedDisplayValuesRef.current, displayValues)) {
+        updatedDisplayValuesRef.current = {};
+      }
     }, [displayValues]);
 
     return (


### PR DESCRIPTION
新增可在字段中配置 Summary List，以及支持 Summary List 与表单的交互（比如移除表单项）。

## 配置 Summary List
### 配置项
配置项的数据结构如下：
```js
{
  summaryConfig: Type.Object({
    type: StringUnion(["auto", "item"]),
    label: Type.String(),
    value: Type.String(),
    icon: Type.String(),
    hidden: Type.Boolean(),
  }),
}
```
部分字段解析：
- `type`：选择 `auto` 时 Summary List 会自动按照字段的类型来展示对应的表单信息。但有时候我们可能不想要自动处理，比如字段为 `annotations` 时，我们可能希望设置和展示它的子字段而非整个 `annotations` 对象，这时候就可以选择为 `item`，并配置对应的 `label` 和 `value`
- `hidden`: 有一些字段可能不希望在 Summary List 中展示，可以设置为隐藏
- `icon`: 虽然可以直接读取字段中的图标进行展示，但是 Summary List 中的图标大小可能和表单中的不同，所以允许单独设置

## 与表单交互
Summary List 与表单交互中有两个点要考虑，一个是 Summary List 要怎么知道表单项是否是可交互的，另一个是触发交互后要怎么交给对应的表单项进行处理。于是我在 KAF 新增一个 `services` 对象，用于 KAF 内部各结构的数据交换与事件通信。

```js
const services = {
  store: { ... },
  setStore: (store)=> ...,
  event: mitt(...)
};
```

### 判断可交互
在 `services.store` 中新增一个 `summary` 属性用于存储 Summary List 所需的数据：
```js
const services = {
  store: { 
    summary: {
      removableMap: {}
    }  
  },
  setStore: (store)=> ...,
  event: mitt(...)
};
```

Widget 表单项可以通过 `setStore` 来设置自己是否为可移除的状态：
```js
useEffect(()=> {
  const store = set(serivce.store, `summary.removableMap.${field.key}`, true);

  setStore({ ...store });
}, [...])
```

### 处理交互

Widget 可通过 `services.event` 来订阅对应的交互来进行处理：
```js
useEffect(()=> {
  services.event.on('remove', handleRemoveEvent);

  return ()=> {
    services.event.off('remove', handleRemoveEvent);
  }
})
```

## 预览
![image](https://user-images.githubusercontent.com/25414733/208069779-e4360252-0686-4237-bb67-da7143a65588.png)

![image](https://user-images.githubusercontent.com/25414733/208069930-9c003f3f-ec2c-4c84-9321-fe30f284be06.png)
